### PR TITLE
Use xJdfLib 0.15.1 hotfix: Do not restrict the DropItems ItemRefs to an XJDF Resource

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-runtime', version: '0.12.0'
     compile group: 'org.jetbrains', name: 'annotations', version: '13.0'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.7'
-    compile group: 'org.cip4.lib.xjdf', name: 'xJdfLib', version: '0.15'
+    compile group: 'org.cip4.lib.xjdf', name: 'xJdfLib', version: '0.15.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.10.0'


### PR DESCRIPTION
This MR is based on https://github.com/cip4/xJdfLib/pull/63 and will fix the handling with print talks as well